### PR TITLE
Add tooling for Theos self-hosted runner builds

### DIFF
--- a/.github/workflows/theos-build.yml
+++ b/.github/workflows/theos-build.yml
@@ -1,0 +1,61 @@
+name: Theos Build
+
+on:
+  push:
+    paths:
+      - 'ios/**'
+      - '.github/workflows/theos-build.yml'
+      - 'ios/Scripts/**'
+  pull_request:
+    paths:
+      - 'ios/**'
+      - '.github/workflows/theos-build.yml'
+      - 'ios/Scripts/**'
+
+jobs:
+  build:
+    name: Build (self-hosted Theos)
+    runs-on:
+      - self-hosted
+      - linux
+      - theos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load Theos environment
+        shell: bash
+        run: |
+          if [ -f "$HOME/.profile" ]; then
+            source "$HOME/.profile"
+          fi
+          echo "THEOS=${THEOS:-$HOME/theos}" >> "$GITHUB_ENV"
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
+
+      - name: Validate Theos installation
+        shell: bash
+        run: |
+          if [ ! -d "${THEOS:-$HOME/theos}" ]; then
+            echo "Theos directory not found at ${THEOS:-$HOME/theos}." >&2
+            exit 1
+          fi
+          echo "Using Theos from ${THEOS:-$HOME/theos}"
+          which nic || true
+
+      - name: Build package
+        shell: bash
+        run: |
+          source "$HOME/.profile" 2>/dev/null || true
+          if [ -f Makefile ]; then
+            make package
+          else
+            echo "No Makefile found. Skipping Theos build."
+          fi
+
+      - name: Upload packages
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: theos-packages
+          path: packages/**/*.deb
+          if-no-files-found: ignore

--- a/ios/Docs/SelfHostedTheosRunner.md
+++ b/ios/Docs/SelfHostedTheosRunner.md
@@ -1,0 +1,69 @@
+# Self-Hosted Runner Setup for Theos Builds
+
+This guide documents how to prepare a Linux-based GitHub Actions self-hosted runner that can compile the Dab iOS project using [Theos](https://theos.dev/). The process is split into three stages:
+
+1. Provisioning the runner machine.
+2. Installing Theos and required toolchains.
+3. Wiring the runner into GitHub Actions for continuous integration.
+
+## 1. Provision the Runner Machine
+
+1. Start from an Ubuntu 22.04 LTS host (physical, VM, or container) with at least 2 CPU cores, 4 GB RAM, and 20 GB free disk space.
+2. Create a dedicated system user, e.g. `dab-runner`, and install the GitHub Actions runner binary following the [official documentation](https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners).
+3. When prompted during runner registration, add the custom label `theos` in addition to the defaults (`self-hosted`, `linux`, `X64`). The workflow defined in this repository uses the `theos` label to target the correct machine.
+
+> **Tip:** Place the runner service files under `/opt/actions-runner` and install it as a systemd service so that it automatically restarts after reboots.
+
+## 2. Install Theos and Toolchains
+
+We provide a helper script that bootstraps the environment with all required packages and Theos dependencies.
+
+```bash
+# From the repository root
+sudo ios/Scripts/setup-theos-runner.sh
+```
+
+The script performs the following tasks:
+
+- Installs compilers and utilities: `clang`, `llvm`, `make`, `cmake`, `ldid`, `fakeroot`, etc.
+- Configures the Procursus APT repository (only once) to supply modern iOS tooling such as `ldid`.
+- Clones or updates the [`theos/theos`](https://github.com/theos/theos) and [`theos/templates`](https://github.com/theos/templates) repositories under `~/theos` for the runner user.
+- Appends `THEOS` and `PATH` exports to the runner user's `~/.profile` so the environment is available for both interactive shells and GitHub Actions jobs.
+
+After running the script, restart the GitHub Actions runner service so that the refreshed environment variables take effect:
+
+```bash
+sudo systemctl restart actions.runner.<org>-<repo>.service
+```
+
+Replace `<org>` and `<repo>` with the actual values shown when the runner service was installed.
+
+## 3. Configure GitHub Actions
+
+This repository now includes a workflow (`.github/workflows/theos-build.yml`) that targets the `theos`-labeled self-hosted runner. The workflow executes the following steps on every push and pull request:
+
+1. Checkout the repository.
+2. Source the Theos environment exports.
+3. Invoke `make package` (or another target you configure) to build the project.
+4. Archive any generated `.deb` artifacts for download.
+
+If your Theos project uses a different build command or workspace, update the workflow accordingly.
+
+### Testing the Setup Locally
+
+Before relying on CI, manually validate the runner environment:
+
+```bash
+source ~/.profile
+make clean package
+```
+
+Ensure the build completes without errors and that the resulting package appears under `packages/`.
+
+## Troubleshooting
+
+- **Missing SDKs:** Theos requires an iOS SDK. If you do not have one, download the latest SDK from your macOS toolchain and place it under `$THEOS/sdks/`.
+- **Permission errors:** Confirm the runner user owns the `~/theos` directory and the repository workspace. Avoid running the GitHub Actions service as `root`.
+- **Outdated toolchain:** Re-run `ios/Scripts/setup-theos-runner.sh` periodically to pull the latest Theos commits and ensure dependencies remain up to date.
+
+With these steps complete, your Linux self-hosted runner can continuously build the Dab iOS project using Theos.

--- a/ios/README.md
+++ b/ios/README.md
@@ -7,7 +7,7 @@ This directory holds the new Swift-based implementation for the Dab application.
 - `Package.swift` – Swift Package manifest that lets us bootstrap the project before generating an Xcode workspace.
 - `Sources/App/` – SwiftUI entry point and shared application scaffolding.
 - `Resources/` – Placeholder for assets that will be ported or recreated for iOS.
-- `Docs/` – Design notes, technical decisions, and references collected during development.
+- `Docs/` – Design notes, technical decisions, and references collected during development. See [`Docs/SelfHostedTheosRunner.md`](Docs/SelfHostedTheosRunner.md) for guidance on preparing a Linux self-hosted runner with Theos.
 
 ## Next Steps
 

--- a/ios/Scripts/setup-theos-runner.sh
+++ b/ios/Scripts/setup-theos-runner.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap a Linux machine for running Theos builds via a self-hosted GitHub Actions runner.
+# Usage: ./setup-theos-runner.sh
+
+if [[ $(id -u) -ne 0 ]]; then
+  echo "[setup-theos] Re-running script with sudo for privileged operations"
+  exec sudo --preserve-env=THEOS "$0" "$@"
+fi
+
+TARGET_USER="${SUDO_USER:-root}"
+TARGET_HOME=$(getent passwd "$TARGET_USER" | cut -d: -f6)
+THEOS_DIR="${THEOS:-$TARGET_HOME/theos}"
+PROCUSUS_SOURCE_LIST="/etc/apt/sources.list.d/procursus.list"
+
+log() {
+  echo "[setup-theos] $*"
+}
+
+log "Updating apt repositories"
+apt-get update -y
+
+ensure_package() {
+  local package="$1"
+  if ! dpkg -s "$package" >/dev/null 2>&1; then
+    log "Installing package: $package"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y "$package"
+  else
+    log "Package already installed: $package"
+  fi
+}
+
+for pkg in git curl make cmake clang llvm lld python3 python3-pip perl unzip rsync fakeroot dpkg-dev libz-dev zstd ca-certificates libssl-dev libxml2-dev gnupg; do
+  ensure_package "$pkg"
+done
+
+if ! command -v ldid >/dev/null 2>&1; then
+  log "Configuring Procursus repository for ldid"
+  if [[ ! -f "$PROCUSUS_SOURCE_LIST" ]]; then
+    echo "deb [arch=amd64] https://apt.procurs.us/ bullseye main" > "$PROCUSUS_SOURCE_LIST"
+  fi
+  if ! apt-key list | grep -q "Procursus"; then
+    curl -fsSL https://apt.procurs.us/documents/apt-key.gpg | apt-key add -
+  fi
+  apt-get update -y
+  ensure_package ldid
+else
+  log "ldid already available"
+fi
+
+log "Ensuring Theos is present at $THEOS_DIR"
+if [[ ! -d "$THEOS_DIR" ]]; then
+  git clone --recursive https://github.com/theos/theos.git "$THEOS_DIR"
+else
+  pushd "$THEOS_DIR" >/dev/null
+  git pull --recurse-submodules --ff-only
+  git submodule update --init --recursive
+  popd >/dev/null
+fi
+
+log "Ensuring Theos templates are installed"
+if [[ ! -d "$THEOS_DIR/templates" ]]; then
+  git clone https://github.com/theos/templates.git "$THEOS_DIR/templates"
+else
+  pushd "$THEOS_DIR/templates" >/dev/null
+  git pull --ff-only
+  popd >/dev/null
+fi
+
+profile_file="$TARGET_HOME/.profile"
+
+if ! grep -q "export THEOS=" "$profile_file" 2>/dev/null; then
+  {
+    echo "export THEOS=\"$THEOS_DIR\""
+    echo 'export PATH="$THEOS/bin:$PATH"'
+  } >> "$profile_file"
+  log "Appended THEOS exports to $profile_file"
+else
+  log "THEOS exports already present in $profile_file"
+fi
+
+log "Bootstrap complete. Restart the GitHub Actions runner service to pick up changes if necessary."


### PR DESCRIPTION
## Summary
- add documentation for provisioning a Linux self-hosted runner with Theos tooling
- provide a bootstrap script that installs Theos dependencies and configures environment variables
- wire up a GitHub Actions workflow that targets a theos-labeled self-hosted runner and packages artifacts when available

## Testing
- bash -n ios/Scripts/setup-theos-runner.sh

------
https://chatgpt.com/codex/tasks/task_e_68d677c91ca8832fa0022d6eb87cf5a6