### PR TITLE
Improve auth form validation and state handling

### DIFF
--- a/ios/Sources/App/Features/Auth/AuthViewModel.swift
+++ b/ios/Sources/App/Features/Auth/AuthViewModel.swift
@@ -34,6 +34,10 @@ final class AuthViewModel: ObservableObject {
     private let authService: AuthenticationService
     private let tokenStore: SecureTokenStore
 
+    var canSubmit: Bool {
+        !normalizedEmail.isEmpty && !normalizedPassword.isEmpty && !isLoading
+    }
+
     init(authService: AuthenticationService, tokenStore: SecureTokenStore) {
         self.authService = authService
         self.tokenStore = tokenStore
@@ -69,19 +73,27 @@ final class AuthViewModel: ObservableObject {
     }
 
     func signIn() async {
-        guard !email.isEmpty, !password.isEmpty else {
+        guard !isLoading else { return }
+
+        let normalizedEmail = self.normalizedEmail
+        let normalizedPassword = self.normalizedPassword
+
+        guard !normalizedEmail.isEmpty, !normalizedPassword.isEmpty else {
             errorMessage = AuthError.invalidCredentials.errorDescription
             return
         }
 
+        email = normalizedEmail
+        password = normalizedPassword
         isLoading = true
         errorMessage = nil
 
         do {
-            let credentials = AuthCredentials(email: email, password: password)
+            let credentials = AuthCredentials(email: normalizedEmail, password: normalizedPassword)
             let tokens = try await authService.signIn(with: credentials)
             try tokenStore.save(tokens: tokens)
             activeTokens = tokens
+            password = ""
             animateTransition(to: .success)
         } catch let authError as AuthError {
             errorMessage = authError.errorDescription
@@ -131,5 +143,13 @@ final class AuthViewModel: ObservableObject {
 #else
         step = newStep
 #endif
+    }
+
+    private var normalizedEmail: String {
+        email.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var normalizedPassword: String {
+        password.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/ios/Sources/App/Features/Auth/OnboardingFlowView.swift
+++ b/ios/Sources/App/Features/Auth/OnboardingFlowView.swift
@@ -119,7 +119,7 @@ private struct SignInView: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(viewModel.isLoading)
+                .disabled(!viewModel.canSubmit)
 
                 Button("Forgot password?") {}
                     .buttonStyle(.borderless)

--- a/ios/Tests/AppTests/AuthViewModelTests.swift
+++ b/ios/Tests/AppTests/AuthViewModelTests.swift
@@ -49,6 +49,51 @@ final class AuthViewModelTests: XCTestCase {
         XCTAssertEqual(sut.errorMessage, AuthError.invalidCredentials.errorDescription)
     }
 
+    func testCanSubmitReflectsCredentialAndLoadingState() async {
+        let sut = AuthViewModel(
+            authService: MockAuthenticationService(behaviour: .success),
+            tokenStore: InMemorySecureTokenStore()
+        )
+
+        XCTAssertFalse(sut.canSubmit)
+
+        sut.email = "   "
+        sut.password = " \t"
+        XCTAssertFalse(sut.canSubmit)
+
+        sut.email = "user@example.com"
+        sut.password = "password"
+        XCTAssertTrue(sut.canSubmit)
+
+        let signInTask = Task {
+            await sut.signIn()
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertFalse(sut.canSubmit)
+
+        await signInTask.value
+        XCTAssertFalse(sut.canSubmit)
+    }
+
+    func testSignInTrimsWhitespaceFromCredentials() async throws {
+        let tokenStore = InMemorySecureTokenStore()
+        let sut = AuthViewModel(
+            authService: MockAuthenticationService(behaviour: .success),
+            tokenStore: tokenStore
+        )
+
+        sut.advanceFromWelcome()
+        sut.email = "  user@example.com  "
+        sut.password = "  password  "
+
+        await sut.signIn()
+
+        XCTAssertEqual(sut.email, "user@example.com")
+        XCTAssertEqual(sut.password, "")
+        XCTAssertNotNil(try tokenStore.loadTokens())
+    }
+
     func testRefreshSessionHandlesExpiry() async {
         let tokenStore = InMemorySecureTokenStore()
         try? tokenStore.save(tokens: AuthTokens(accessToken: "signed_in_access", refreshToken: "stale_token", expiresAt: .distantPast))


### PR DESCRIPTION
## Summary
- add derived `canSubmit` state to `AuthViewModel` to prevent duplicate sign-ins and trim whitespace from credentials
- clear persisted password after successful authentication and expose the derived state to SwiftUI for better button disabling
- expand AuthViewModel test coverage to cover validation, whitespace trimming, and loading behaviour

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d70d86238c832fb02bcd0411b215bb